### PR TITLE
Фикс установки & неправильных тайп-хинтов

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ ___
 # Dependencies:
 * mpv
 * ffmpeg (опционально, для скачивания видео через аргумент "**-d**")
-* python 3.6+
+* python 3.7+
 * pip
 * requests
 ___

--- a/anicli.py
+++ b/anicli.py
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+from __future__ import annotations
 from os import system
 from os import name as sys_name
 import argparse

--- a/anicli_ru/api.py
+++ b/anicli_ru/api.py
@@ -1,7 +1,8 @@
-import re
+from __future__ import annotations
 from html import unescape
 from typing import Union
 from anicli_ru.base import ListObj, BaseObj, BaseAnime
+import re
 
 
 class AnimeResult(BaseObj):

--- a/anicli_ru/api2.py
+++ b/anicli_ru/api2.py
@@ -1,5 +1,5 @@
+from __future__ import annotations
 from typing import Union, List
-
 from anicli_ru.base import BaseAnime, ListObj, BaseObj
 from html.parser import unescape
 import re

--- a/anicli_ru/base.py
+++ b/anicli_ru/base.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
 from requests import Session
 from collections import UserList
-import re
 from html.parser import unescape
 from .utils import kodik_decoder
+import re
 
 # aniboom regular expressions (work after unescape response html page)
 RE_ANIBOOM = re.compile(r'"hls":"{\\"src\\":\\"(.*\.m3u8)\\"')

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,9 @@
-from pathlib import Path
 from setuptools import setup
-
 from anicli_ru import __version__
 
-this_directory = Path(__file__).parent
-long_description = (this_directory / "README.md").read_text()
+with open("README.md", encoding="utf-8") as f:
+    long_description = f.read()
+
 setup(
     name='anicli-ru',
     version=__version__,


### PR DESCRIPTION
Установка падала из-за символов UTF-8 в README, а из-за сломанных тайп-хинтов код не выполнялся.

Все тесты проходят.