### PR TITLE
nix: fix overlay building and don't use rec in package

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -9,31 +9,31 @@
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs =
-    inputs:
-    inputs.flake-utils.lib.eachDefaultSystem (
-      system:
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    let
+      supportedSystems = [ "x86_64-linux" "aarch64-linux" ];
+    in
+    flake-utils.lib.eachSystem supportedSystems (system:
       let
-        pkgs = import inputs.nixpkgs {
-          inherit
-            system
-            ;
+        pkgs = import nixpkgs { 
+          inherit system;
         };
       in
-      rec {
+      {
         packages = {
           anicli-ru = pkgs.callPackage ./nix/package.nix { };
-          default = packages.anicli-ru;
+          default = self.packages.${system}.anicli-ru;
         };
+        
         devShells = {
           default = pkgs.mkShell {
-            buildInputs = [ packages.default ];
+            buildInputs = [ self.packages.${system}.default ];
           };
         };
-        overlays = {
-          default = final: prev: {
-            anicli-ru = packages.default;
-          };
+        
+        overlays = final: prev: {
+          anicli-ru = self.packages.${system}.anicli-ru;
+          default = self.packages.${system}.anicli-ru;
         };
       }
     );

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -11,16 +11,17 @@ let
 in
 with pyPkgs;
 
-buildPythonApplication rec {
-  pname = "anicli_ru";
-  version = "5.0.16";
+let
+    pname = "anicli_ru";
+    version = "5.0.16";
+in
+
+buildPythonApplication {
+  inherit pname version;
   pyproject = true;
 
   src = pkgs.fetchPypi {
-    inherit
-      pname
-      version
-      ;
+    inherit pname version;
     hash = "sha256-gM9on15RQIpQVJfWW/uPeN63vSSbCJt2mNN5zkvc5Jg=";
   };
 
@@ -61,6 +62,7 @@ buildPythonApplication rec {
         github = "mctrxnv";
         githubId = 189107707;
       }
+      ch4og
     ];
     mainProgram = "anicli-ru";
   };


### PR DESCRIPTION
In current realization overlay declaration was wrong. Using rec in flakes and packages is not recommended and is a bad practice. Previous realization was not evaluating fully on all supported platforms. 

В текущей реализации объявление оверлея было неверным. Использование rec в flakes и пакетах не рекомендуется и является плохой практикой. Предыдущая реализация не работала полностью на всех поддерживаемых платформах.