### PR TITLE
nix: refactoring, afl3 -> gpl3 (my bad), nix caches is off

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -4,12 +4,6 @@
     ! Only in TUI mode !
   '';
 
-  nixConfig = {
-    substitute = false;
-    substituters = "";
-    trusted-public-keys = "";
-  };
-
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
@@ -48,13 +42,17 @@
 
         devShells = {
           default = pkgs.mkShell {
-            buildInputs = [ self.packages.${system}.default ];
+            buildInputs = [
+              self.packages.${system}.default
+            ];
           };
         };
 
         overlays = final: prev: {
-          anicli-ru = self.packages.${system}.anicli-ru;
-          default = self.packages.${system}.anicli-ru;
+          inherit (self.packages.${system})
+            anicli-ru
+            default
+            ;
         };
       }
     );

--- a/nix/api.nix
+++ b/nix/api.nix
@@ -5,14 +5,19 @@
   hatchling,
   httpx,
   parsel,
-  #
-  version ? null,
-  hash ? null,
 }:
 
-buildPythonApplication rec {
+let
   pname = "anicli_api";
-  inherit version;
+  version = "0.7.14";
+  hash = "sha256-zmB2U4jyDPCLuykUc6PyrlcTULaXDxQ8ZvyTmJfOI0s=";
+in
+
+buildPythonApplication {
+  inherit
+    pname
+    version
+    ;
   pyproject = true;
   dontCheckRuntimeDeps = true;
 

--- a/nix/eggella.nix
+++ b/nix/eggella.nix
@@ -3,14 +3,19 @@
   fetchPypi,
   hatchling,
   prompt-toolkit,
-  #
-  version ? null,
-  hash ? null,
 }:
 
-buildPythonApplication rec {
+let
   pname = "eggella";
-  inherit version;
+  version = "0.1.7";
+  hash = "sha256-8Vo39BePA86wcLKs/F+u2N7tpIpPrEyEPp3POszy050=";
+in
+
+buildPythonApplication {
+  inherit
+    pname
+    version
+    ;
   pyproject = true;
 
   src = fetchPypi {

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,20 +1,17 @@
 {
+  lib,
   buildPythonApplication,
   callPackage,
   fetchPypi,
   hatchling,
   mpv,
   tqdm,
-  #
-  lib,
 }:
-
-# watch anime in terminal (cli)
-# only russian sources
 
 let
   pname = "anicli_ru";
   version = "5.0.16";
+  hash = "sha256-gM9on15RQIpQVJfWW/uPeN63vSSbCJt2mNN5zkvc5Jg=";
 in
 
 buildPythonApplication {
@@ -28,8 +25,8 @@ buildPythonApplication {
     inherit
       pname
       version
+      hash
       ;
-    hash = "sha256-gM9on15RQIpQVJfWW/uPeN63vSSbCJt2mNN5zkvc5Jg=";
   };
 
   build-system = [
@@ -39,14 +36,8 @@ buildPythonApplication {
   dependencies = [
     mpv
     tqdm
-    (callPackage ./eggella.nix {
-      version = "0.1.7";
-      hash = "sha256-8Vo39BePA86wcLKs/F+u2N7tpIpPrEyEPp3POszy050=";
-    })
-    (callPackage ./api.nix {
-      version = "0.7.14";
-      hash = "sha256-zmB2U4jyDPCLuykUc6PyrlcTULaXDxQ8ZvyTmJfOI0s=";
-    })
+    (callPackage ./eggella.nix { })
+    (callPackage ./api.nix { })
   ];
 
   meta = with lib; {
@@ -55,7 +46,7 @@ buildPythonApplication {
       ! only russian sources !
     '';
     homepage = "https://github.com/vypivshiy/ani-cli-ru";
-    license = licenses.gpl3;
+    license = licenses.gpl3Plus;
     platforms = platforms.linux;
     maintainers = with maintainers; [
       DADA30000


### PR DESCRIPTION
я так тупанул и перепутал [afl3](https://github.com/vypivshiy/ani-cli-ru/blob/d135aedf00f228ca5d069a05acced4919de886ac/nix/package.nix#L55) с [gpl3](https://github.com/mctrxnv/ani-cli-ru/blob/ddf6f283c2a28677c574d4018b30c67ccdabe137/nix/package.nix#L58), сорян хихи))

от друга узнал что если вместо `pkgs` вписать сразу явные зависисмости, поэтому: билдиться будет быстрее и можно будет оверрайдить/перезаписывать версии зависимостей, для того чтобы не нажимать y в этих меню
```
❯ nix build
do you want to allow configuration setting 'substitute' to be set to 'false' (y/N)? y
do you want to permanently mark this value as trusted (y/N)? y
do you want to allow configuration setting 'substituters' to be set to '' (y/N)? y
do you want to permanently mark this value as trusted (y/N)? y
do you want to allow configuration setting 'trusted-public-keys' to be set to '' (y/N)? y
do you want to permanently mark this value as trusted (y/N)? y
```
советую при `run` `build` или `shell` добавить`--accept-flake-config`
или если прям доверяете `nix.settings.accept-flake-config = true;`

ну и просто запуск и билд стал быстрее потому что кэш отрублен, а нахуй надо? если это python пакет который не компилируется

также снова форматнул файлики @ch4og, живем